### PR TITLE
Update JOB variable in DuinoCoin_Esp_Async_Master/DuinoCoin_Esp_Async_Master.ino 

### DIFF
--- a/DuinoCoin_Esp_Async_Master/DuinoCoin_Wire.ino
+++ b/DuinoCoin_Esp_Async_Master/DuinoCoin_Wire.ino
@@ -16,11 +16,14 @@
 #define SCL 22
 #endif
 
+#define WIRE_CLOCK 100000
+
 void wire_setup()
 {
   //pinMode(SDA, INPUT_PULLUP);
   //pinMode(SCL, INPUT_PULLUP);
   Wire.begin(SDA, SCL);
+  Wire.setClock(WIRE_CLOCK);
   wire_readAll();
 }
 


### PR DESCRIPTION
Miners didn't get recognized because of the typo in the JOB variable for ESP8266 boards